### PR TITLE
fix two typos in rescue block

### DIFF
--- a/lib/lita/handlers/xkcd.rb
+++ b/lib/lita/handlers/xkcd.rb
@@ -16,7 +16,7 @@ module Lita
 
         response.reply print_comic(MultiJson.load(resp.body))
       rescue
-        reponse.reply error
+        response.reply error
       end
 
       def xkcd_num(response)
@@ -40,7 +40,7 @@ module Lita
 
         response.reply load_comic(comic_num)
       rescue
-        reponse.reply error
+        response.reply error
       end
 
       private


### PR DESCRIPTION
With these typos, an error in fetching the comic data will trigger another exception and the user will get no response at all.

It'd be nice to print more details of the error, but printing *something* is better than nothing.