### PR TITLE
Run travis builds on MRI 2.0 -> 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ rvm:
 script: bundle exec rspec
 before_install:
   - gem update --system
+  - gem update bundler
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 rvm:
   - 2.0.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4.0
 script: bundle exec rspec
 before_install:
   - gem update --system


### PR DESCRIPTION
The travis build has been running on MRI 2.0 only, and failing due to an issue in the version of bundler.

I've added extra builds for MRY 2.1 to 2.4 plus a bundler update to get the build on 2.0 passing again.